### PR TITLE
Add create_tenant_command method as v2.2.0

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -94,19 +94,9 @@ module Apartment
       end
 
       def create_tenant_command(conn, tenant)
-        # NOTE: This was causing some tests to fail because of the database strategy for rspec
-        if ActiveRecord::Base.connection.open_transactions.positive?
-          conn.execute(%(CREATE SCHEMA "#{tenant}"))
-        else
-          schema = %(BEGIN;
-          CREATE SCHEMA "#{tenant}";
-          COMMIT;)
-
-          conn.execute(schema)
-        end
-      rescue *rescuable_exceptions => e
-        rollback_transaction(conn)
-        raise e
+        # As original apartment gem 2.2.0
+        # https://github.com/influitive/apartment/blob/v2.2.0/lib/apartment/adapters/postgresql_adapter.rb#L84
+        conn.execute(%{CREATE SCHEMA "#{tenant}"})
       end
 
       def rollback_transaction(conn)


### PR DESCRIPTION
Fix for Parallel
```ruby
ActiveRecord::ConnectionNotEstablished:
  connection is closed
```

*Addresses [Pivotal 185236518 - Parallel specs connection not established](https://www.pivotaltracker.com/story/show/185236518)*

Tracked down issue to apartment and ros-apartment gem create_tenant_command method due execute and rescue rollback_transaction at postgresql_adapter.rb

v2.2
https://github.com/influitive/apartment/blob/v2.2.0/lib/apartment/adapters/postgresql_adapter.rb

2.11
https://github.com/rails-on-services/apartment/blob/2.11.0/lib/apartment/adapters/postgresql_adapter.rb#L96